### PR TITLE
Better width supporting

### DIFF
--- a/src/jquery.selectik.js
+++ b/src/jquery.selectik.js
@@ -28,8 +28,16 @@
              cselect = element;
 
 		selectik.init = function() {
-		// merged properties
-				settings = $.extend({}, _defaults, options);
+			// merged properties
+			settings = $.extend({}, _defaults, options);
+			//Check select width
+			//Select width is inconsistent in different browser,
+			//so we wrap select by inline element and get it's width
+			if( settings.width == 0 ) {
+			    $cselect.wrap('<span/>');
+			    settings.width = $cselect.parent().width();
+			    $cselect.parent().replaceWith( $cselect );
+			}
 			// fire start functions
 			_getHtml();
 			_handlers();
@@ -83,9 +91,8 @@
 
 			// give width to elements
 			$container.removeClass('done');
-			var width = (settings.width > 0) ? settings.width :  $cselect.outerWidth();
 
-			selectik.setWidthCS(width);
+			selectik.setWidthCS(settings.width);
 			standardTop = parseInt($listContainer.css('top'));
 
 

--- a/src/jquery.selectik.js
+++ b/src/jquery.selectik.js
@@ -341,8 +341,14 @@
 
 		// public method: width of select
 		selectik.setWidthCS = function(width){
-			$list.css('width', width);
-			$text.css('width', width);
+			//Paddings may has element or/and it's parent
+			$.each([$list,$text],function() {
+				var $parent   = $(this).parent(),
+				parentPaddings  = $parent.outerWidth() - $parent.width(),
+				elementPaddings = $(this).outerWidth() - $(this).width(),
+				paddings = parentPaddings + elementPaddings;
+				$(this).css('width', width - paddings);
+			});
 		};
 		selectik.init();
 	};


### PR DESCRIPTION
Selectik selects should be the same width, as original selects in my use case (  guess, this is widely used case). 

The default settings doesn't provide it. When the width is 0, the width calculates wrong. Also, if I set some paddings and borders (set in default stylesheet) - custom select become wider than original select.

In these two commits i've fixed setWidthCS function, to reduce width onto paddings and borders. 
Also, I've improved width detection of original select. 

Now, It works fine with default settings.
