### PR TITLE
Event bubbling on change

### DIFF
--- a/src/jquery.selectik.js
+++ b/src/jquery.selectik.js
@@ -218,7 +218,7 @@
 
 			// change on original select
 			this.$cselect.bind('change', function(){
-				 if (selectik.change) { selectik.change = false; return false; }
+				 if (selectik.change) { selectik.change = false; return true; }
 				 selectik._changeSelected($('option:selected', $(this)));
 			});
 


### PR DESCRIPTION
when change happens and false is returned, default event is blocked, so it cannot be detected by .on(), etc.
