### PR TITLE
Add allowable data-selectik override in options

### DIFF
--- a/src/jquery.selectik.js
+++ b/src/jquery.selectik.js
@@ -94,11 +94,9 @@
 			this.$collection = this.$cselect.children();
 			var html = '';
 			for (var i = 0; i < this.$collection.length; i++){
-				var $this = $(this.$collection[i]);
-				var textOption = ($this.attr('data-selectik')) ? $this.attr('data-selectik') : $this[0].text;
-				var valueOption = $this[0].value;
-				html += '<li class="'+ ($this.attr('disabled') === 'disabled' ? 'disabled' : '') +'" data-value="'+valueOption+'">'+textOption+'</li>';
-			};
+        			var $this = $(this.$collection[i]);
+			        html += '<li class="'+ ($this.attr('disabled') === 'disabled' ? 'disabled' : '') +'" data-value="'+$this[0].value+'">'+($this.data('selectik') ? $this.data('selectik') : $this[0].text)+'</li>';
+			 };
 			return html;
 		},
 		_getLength: function(e){

--- a/src/jquery.selectik.js
+++ b/src/jquery.selectik.js
@@ -96,7 +96,7 @@
 			for (var i = 0; i < this.$collection.length; i++){
 				var $this = $(this.$collection[i]);
 				var textOption = $this[0].text;
-                var valueOption = $this[0].value;
+                		var valueOption = $this[0].value;
 				if($this.attr('data-selectik'))
 				{
 					textOption = $this.attr('data-selectik');

--- a/src/jquery.selectik.js
+++ b/src/jquery.selectik.js
@@ -97,6 +97,10 @@
 				var $this = $(this.$collection[i]);
 				var textOption = $this[0].text;
                 var valueOption = $this[0].value;
+				if($this.attr('data-selectik'))
+				{
+					textOption = $this.attr('data-selectik');
+				}
 				html += '<li class="'+ ($this.attr('disabled') === 'disabled' ? 'disabled' : '') +'" data-value="'+valueOption+'">'+textOption+'</li>';
 			};
 			return html;

--- a/src/jquery.selectik.js
+++ b/src/jquery.selectik.js
@@ -95,12 +95,8 @@
 			var html = '';
 			for (var i = 0; i < this.$collection.length; i++){
 				var $this = $(this.$collection[i]);
-				var textOption = $this[0].text;
-                		var valueOption = $this[0].value;
-				if($this.attr('data-selectik'))
-				{
-					textOption = $this.attr('data-selectik');
-				}
+				var textOption = ($this.attr('data-selectik')) ? $this.attr('data-selectik') : $this[0].text;
+				var valueOption = $this[0].value;
 				html += '<li class="'+ ($this.attr('disabled') === 'disabled' ? 'disabled' : '') +'" data-value="'+valueOption+'">'+textOption+'</li>';
 			};
 			return html;


### PR DESCRIPTION
![Screenshot_1_31_13_8_02_PM](https://f.cloud.github.com/assets/170333/116878/61b0d364-6c0b-11e2-97ce-cd88f8c12ea8.png)
![skitch](https://f.cloud.github.com/assets/170333/116879/7055712c-6c0b-11e2-8279-a5e3f275956b.png)

Hi,

I came across the need for this override - here is the use case:

Need formatted line breaks in value ie: < option value="long option" >Long < br / > Option< /option > so that the selectik version shows the html BR..  problem is, on an iOS device, it overrides the text / formatting and show the <br /> as plain text in the selection.

Additionally, if i put the BR in the value, or leave it out, then once an option is selected, it shows condensed in the selected state...  Lastly, if i put the BR in the value, it gets submitted - which i don't want
